### PR TITLE
Update to Caddy 2.7.4 and route53 provider 1.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-ARG CADDY_VERSION="2.4.6"
+ARG CADDY_VERSION="2.7.4"
 
 FROM caddy:${CADDY_VERSION}-builder-alpine as builder
 
-ARG DNS_PLUGIN_VERSION="1.1.3"
+ARG DNS_PLUGIN_VERSION="1.3.3"
 
 RUN xcaddy build \
   --with github.com/caddy-dns/route53@v${DNS_PLUGIN_VERSION}


### PR DESCRIPTION
Notably this includes the change in Caddy 2.5 which prevents logging of sensitive headers such as Cookie and Authorization.

Has not been battle tested but container log output is identical and dgoss is happy.